### PR TITLE
Move output of last execution to its own attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ curl -X POST \
   * **workflowName** - workflow name that will be instantiated in Conductor
   * **workflowVersion** - workflow version in Conductor
   * **workflowContext** - key/value in json style used as input for new workflow instances.
-    * When a workflow instance is COMPLETED, its output values will be merged to the current schedule workflow context so that these new values will be used on the next workflow instantiation calls as "input".
+    * When a workflow instance is COMPLETED, its output values will be added to the current schedule workflow context under `lastExecution` attribute so that these new values will be used on the next workflow instantiation calls as "input".
     * This may be useful in cases where your workers want to return data that will be used on following workflow calls. For example, workflow instance 1 will process from date 2019-01-01 to 2019-01-15 and its output will be lastDate=2019-01-15; than instance2 from 2019-01-16 to 2019-02-11 and returns lastDate=2019-02-11 and so on.
   * **parallelRuns** - if true, every trigger from timer (according to cron string) will generate a new workflow instance in Conductor. if false, no new workflows will be generated if there are other workflow instances in state RUNNING, so that only one RUNNING instance will be present at a time
   * **correlationId** - passed to Conductor when starting a workflow, see https://netflix.github.io/conductor/gettingstarted/startworkflow/

--- a/schellar/scheduler.go
+++ b/schellar/scheduler.go
@@ -229,12 +229,10 @@ func checkRunningWorkflows() {
 			scheduleMap["lastUpdate"] = time.Now()
 
 			if len(wfoutput) > 0 {
-				logrus.Debugf("Merging workflow output to schedule context. output=%s", wfoutput)
-				m := schedule.WorkflowContext
-				for k, v := range wfoutput {
-					m[k] = v
-				}
-				scheduleMap["workflowContext"] = m
+				schedule.WorkflowContext["lastExecution"] = wfoutput
+				logrus.Debugf("Adding last workflow output to schedule context. output=%s, workflowContext=%s",
+					wfoutput, schedule.WorkflowContext)
+				scheduleMap["workflowContext"] = schedule.WorkflowContext
 			}
 
 			err0 = sch.Update(bson.M{"name": schedule.Name}, bson.M{"$set": scheduleMap})


### PR DESCRIPTION
Previously last execution output was merged with root of workflow
context. This could lead to unexpected shadowing of inputs if same
attribute name is used for inputs and outputs. This commit moves it to
new leaf `lastExecution`.