### PR TITLE
Unify postgres with mongo, enable mongo tests in GH Actions

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,10 +3,19 @@ version: "3.8"
 services:
 
   postgres:
-    image: postgres
+    image: postgres:13
     ports:
       - 6432:5432
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: schellar_test
+
+
+  mongo:
+    image: mongo:4.1.10
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=root
+    ports:
+      - 27017-27019:27017-27019

--- a/schellar/it/db_it.go
+++ b/schellar/it/db_it.go
@@ -76,8 +76,12 @@ func testCRUD(t *testing.T, db ifc.DB, schedule ifc.Schedule) {
 	schedules := ExpectTableSize(db, 1, "after insert", t)
 	actual := schedules[0]
 	if schedule.WorkflowContext == nil {
-		// selected WorkflowContext is never null
+		// selected WorkflowContext is never nil
 		schedule.WorkflowContext = make(map[string]interface{})
+	}
+	if schedule.TaskToDomain == nil {
+		// selected TaskToDomain is never nil
+		schedule.TaskToDomain = make(map[string]string)
 	}
 	assertEquals(t, schedule, actual, "Insert error")
 	// find by name
@@ -163,8 +167,11 @@ func UpdateStatusIntegration(t *testing.T, dbGetter func(*testing.T) ifc.DB) {
 	}
 	schedules := ExpectTableSize(db, 1, "after insert", t)
 	actual := schedules[0]
-	// selected WorkflowContext is never null
+	// selected WorkflowContext is never nil
 	schedule.WorkflowContext = make(map[string]interface{})
+	// selected TaskToDomain is never nil
+	schedule.TaskToDomain = make(map[string]string)
+
 	// check equality
 	assertEquals(t, schedule, actual, "Inserted != selected")
 }
@@ -187,6 +194,9 @@ func UpdateStatusAndWorkflowContextIntegration(t *testing.T, dbGetter func(*test
 	}
 	schedules := ExpectTableSize(db, 1, "after insert", t)
 	actual := schedules[0]
+	// selected TaskToDomain is never nil
+	schedule.TaskToDomain = make(map[string]string)
+
 	// check equality
 	assertEquals(t, schedule, actual, "Inserted != selected")
 }
@@ -207,8 +217,11 @@ func UpdateIntegration(t *testing.T, dbGetter func(*testing.T) ifc.DB) {
 	}
 	schedules := ExpectTableSize(db, 1, "after insert", t)
 	actual := schedules[0]
-	// selected WorkflowContext is never null
+	// selected WorkflowContext is never nil
 	schedule.WorkflowContext = make(map[string]interface{})
+	// selected TaskToDomain is never nil
+	schedule.TaskToDomain = make(map[string]string)
+
 	// check equality
 	assertEquals(t, schedule, actual, "Inserted != selected")
 }

--- a/schellar/mongo/mongo_test.go
+++ b/schellar/mongo/mongo_test.go
@@ -1,0 +1,18 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/frinx/schellar/ifc"
+	"github.com/frinx/schellar/it"
+)
+
+func initIntegration(t *testing.T) ifc.DB {
+	db := InitDB()
+	it.ExpectTableSize(db, 0, "before test", t)
+	return db
+}
+
+func TestAllIntegration(t *testing.T) {
+	it.AllIntegration(t, initIntegration)
+}

--- a/schellar/postgres/postgres.go
+++ b/schellar/postgres/postgres.go
@@ -100,6 +100,9 @@ func (db PostgresDB) queryAll(sql string, args ...interface{}) ([]ifc.Schedule, 
 		if WorkflowContext == nil {
 			WorkflowContext = make(map[string]interface{})
 		}
+		if TaskToDomain == nil {
+			TaskToDomain = make(map[string]string)
+		}
 		schedule := ifc.Schedule{ScheduleName, Enabled, Status, WorkflowName, WorkflowVersion,
 			WorkflowContext, CronString, ParallelRuns, CheckWarningSeconds,
 			FromDate, ToDate, LastUpdate, CorrelationID, TaskToDomain}

--- a/test.sh
+++ b/test.sh
@@ -13,4 +13,8 @@ sleep 5
 export BACKEND="postgres"
 export POSTGRES_DATABASE_URL="host=127.0.0.1 port=6432 user=postgres password=postgres database=schellar_test"
 export POSTGRES_MIGRATIONS_DIR="$(pwd)/migrations"
+export MONGO_ADDRESS=127.0.0.1
+export MONGO_USERNAME=root
+export MONGO_PASSWORD=root
+export MONGO_DB=admin
 go test -run Integration ./...


### PR DESCRIPTION
Make postgres backend return empty map when TaskToDomain is inserted with null.
This is in line with mongo and is expected by conductor.go:35