### PR TITLE
Increased length of cron_string

### DIFF
--- a/schellar/migrations/002_alter_cron_string.sql
+++ b/schellar/migrations/002_alter_cron_string.sql
@@ -1,0 +1,1 @@
+ALTER TABLE schedule ALTER COLUMN cron_string TYPE varchar(20);


### PR DESCRIPTION
- it was not possible to use cron
schedule like 45 16 10 12 *

Signed-off-by: Martin Sunal <msunal@frinx.io>